### PR TITLE
installNrpe.py

### DIFF
--- a/bin/public/installNrpe.py
+++ b/bin/public/installNrpe.py
@@ -98,7 +98,7 @@ def _install_nrpe(args):
 
 def _fix_selinux(type, filename):
     x("chcon -t {0} {1}{2}".format(type, PLG_PATH, filename))
-    x("semanage fcontext -a -t {0} '{1}{2}".format(type, PLG_PATH, filename))
+    x("semanage fcontext -a -t {0} '{1}{2}'".format(type, PLG_PATH, filename))
 
 def _install_nrpe_plugins():
     '''


### PR DESCRIPTION
Changed plugin path to global variable.
Added some new SELinux rules during installation for some custom scripts not getting this during installation. This fixes some of the errors in the current Icinga monitoring, but not all.
