### PR TITLE
Added JVM option

### DIFF
--- a/bin/public/installGlassfish4.py
+++ b/bin/public/installGlassfish4.py
@@ -246,6 +246,7 @@ def _setup_glassfish4():
   asadmin_exec("create-jvm-options '-XX\:MaxPermSize=1024m'")
   asadmin_exec("create-jvm-options -Dhttp.maxConnections=512")
   asadmin_exec("create-jvm-options '-XX\:+UseParallelGC'")
+  asadmin_exec("create-jvm-options -Dcom.sun.enterprise.web.connector.grizzly.linger=-1")
   asadmin_exec("set server.ejb-container.property.disable-nonportable-jndi-names=true")
   asadmin_exec("set configs.config.server-config.ejb-container.ejb-timer-service.property.reschedule-failed-timer=true")
   asadmin_exec("set-log-attributes com.sun.enterprise.server.logging.SyslogHandler.useSystemLogging=true")


### PR DESCRIPTION
Workaround for,

GlassFish/Grizzly not able to accept new request if a remote client hangs (6963818)
Description When closing an idle or expired connection, Grizzly waits a period of time, called the
linger time, for any pending data transmission to complete. If the client on the
connection is not network accessible, GlassFish Server might appear to hang.
