### PR TITLE
Using linux user nrpe instead of nagios on all nrpe related files.

### DIFF
--- a/bin/common/config.py
+++ b/bin/common/config.py
@@ -299,7 +299,6 @@ class Config(object):
         '''
 
         def get_monitor_server_ip(self):
-
             return self._get_service_ip("monitor")
 
         def get_monitor_server_hostname(self):

--- a/bin/common/install.py
+++ b/bin/common/install.py
@@ -46,7 +46,7 @@ def rforge_repo():
 
     """
     package = "rpmforge-release-0.5.2-2.el6.rf.x86_64"
-    fn = "http://packages.sw.be/rpmforge-release/rpmforge-release-0.5.2-2.el6.rf.x86_64.rpm"
+    fn = "http://packages.sw.be/rpmforge-release/rpmforge-release-0.5.3-1.el6.rf.x86_64.rpm"
 
     if not is_rpm_installed(package):
         _yum_protect_base()

--- a/bin/public/installNrpe.py
+++ b/bin/public/installNrpe.py
@@ -39,6 +39,7 @@ def build_commands(commands):
 def install_nrpe(args):
     """Install a hardened NRPE server, plugins and commands."""
     app.print_verbose("Installing nrpe")
+
     version_obj = version.Version("installNrpe", SCRIPT_VERSION)
     version_obj.check_executed()
     _install_nrpe(args)
@@ -59,10 +60,13 @@ def _install_nrpe(args):
     install.epel_repo()
 
     # Confusing that nagios-plugins-all does not really include all plugins
+    # WARNING: nrpe in EPEL and nagios-nrpe in RPMForge are the same package. At
+    # the moment EPEL has the latest version but RPMForge obsolete the EPEL
+    # package. Because of that, exclude nagios-nrpe from RPMForge.
     x(
         "yum install -y nagios-plugins-all nrpe nagios-plugins-nrpe php-ldap "
         "nagios-plugins-perl perl-Net-DNS perl-Proc-ProcessTable"
-        "perl-Date-Calc policycoreutils-python"
+        "perl-Date-Calc policycoreutils-python --exclude=nagios-nrpe"
     )
 
     # Move object structure and prepare conf-file
@@ -81,7 +85,7 @@ def _install_nrpe(args):
     nrpe_config.replace("$(MONITORIP)", monitor_server_front_ip)
 
     # Set permissions for read/execute under nagios-user
-    x("chown -R root:nagios /etc/nagios/")
+    x("chown -R root:nrpe /etc/nagios/")
 
     # Allow nrpe to listen on UDP port 5666
     iptables.add_nrpe_chain()
@@ -118,7 +122,7 @@ def _install_nrpe_plugins():
 
     # Change ownership of plugins to nrpe (from icinga/nagios)
     x("chmod -R 550 /usr/lib64/nagios/plugins/")
-    x("chown -R nagios:nagios /usr/lib64/nagios/plugins/")
+    x("chown -R nrpe:nrpe /usr/lib64/nagios/plugins/")
 
     # Set SELinux roles to allow NRPE execution of binaries such as python/perl.
     # Corresponding .te-files summarize rule content
@@ -158,13 +162,13 @@ def _install_nrpe_plugins_dependencies():
     x("yum install -y perl-suidperl")
 
     x("""cat > /etc/sudoers.d/nrpe << EOF
-Defaults:nagios !requiretty
-nagios ALL=NOPASSWD:{0}check_clamav
-nagios ALL=NOPASSWD:{0}check_clamscan
-nagios ALL=NOPASSWD:{0}check_disk
-nagios ALL=NOPASSWD:{0}get_services
-nagios ALL=NOPASSWD:{0}mysql/pmp-check-mysql-deleted-files
-nagios ALL=NOPASSWD:{0}mysql/pmp-check-mysql-file-privs
+Defaults:nrpe !requiretty
+nrpe ALL=NOPASSWD:{0}check_clamav
+nrpe ALL=NOPASSWD:{0}check_clamscan
+nrpe ALL=NOPASSWD:{0}check_disk
+nrpe ALL=NOPASSWD:{0}get_services
+nrpe ALL=NOPASSWD:{0}mysql/pmp-check-mysql-deleted-files
+nrpe ALL=NOPASSWD:{0}mysql/pmp-check-mysql-file-privs
 EOF
 """.format(PLG_PATH))
 
@@ -185,10 +189,10 @@ EOF
 
         # Let nrpe run hpasmcli and hpacucli
     x("""cat >> /etc/sudoers.d/nrpe << EOF
-nagios ALL=NOPASSWD:/sbin/hpasmcli
-nagios ALL=NOPASSWD:{0}check_hpasm
-nagios ALL=NOPASSWD:/sbin/hpacucli
-nagios ALL=NOPASSWD:{0}check_hparray"
+nrpe ALL=NOPASSWD:/sbin/hpasmcli
+nrpe ALL=NOPASSWD:{0}check_hpasm
+nrpe ALL=NOPASSWD:/sbin/hpacucli
+nrpe ALL=NOPASSWD:{0}check_hparray
 EOF
 """.format(PLG_PATH))
 

--- a/bin/public/iptables.py
+++ b/bin/public/iptables.py
@@ -744,9 +744,11 @@ def add_nrpe_chain():
 
     monitor_listen_port = "5666"
     monitor_server_ip = config.general.get_monitor_server_ip()
+    if monitor_server_ip:
+        monitor_server_ip = '-s %s' % monitor_server_ip
 
     app.print_verbose("Chain for NRPE input from {0}".format(monitor_server_ip))
-    iptables("-A nrpe_input -p TCP -m multiport -s " + monitor_server_ip + " --dports " + monitor_listen_port + " -m state --state NEW -j allowed_tcp")
+    iptables("-A nrpe_input -p TCP -m multiport " + monitor_server_ip + " --dports " + monitor_listen_port + " -m state --state NEW -j allowed_tcp")
 
 
 def del_openvpn_chain():


### PR DESCRIPTION
We had a conflict between EPEL and RPMForge on the nrpe package.
EPEL used nrpe as the linux user and RPMForge used nagios. EPEL
was also using a later version of nrpe. But RPMForge obsoleted the
nrpe version anyway.