### PR TITLE
Docker logging to syslog

### DIFF
--- a/var/docker/docker
+++ b/var/docker/docker
@@ -4,4 +4,7 @@
 # These will be parsed by the sysv initscript and appended
 # to the arguments list passed to docker -d
 
-other_args="-H unix:///var/run/docker.sock -H tcp://0.0.0.0:2375 --log-driver=syslog --log-opt syslog-address=tcp://localhost:514 --log-opt syslog-facility=user --log-opt tag='docker'"
+other_args_net="-H unix:///var/run/docker.sock -H tcp://0.0.0.0:2375"
+other_args_log="--log-driver=syslog --log-opt syslog-address=tcp://localhost:514"
+
+other_args="${other_args_net} ${other_args_log}"

--- a/var/docker/docker
+++ b/var/docker/docker
@@ -4,4 +4,4 @@
 # These will be parsed by the sysv initscript and appended
 # to the arguments list passed to docker -d
 
-other_args="-H unix:///var/run/docker.sock -H tcp://0.0.0.0:2375"
+other_args="-H unix:///var/run/docker.sock -H tcp://0.0.0.0:2375 --log-driver=syslog --log-opt syslog-address=tcp://localhost:514 --log-opt syslog-facility=user --log-opt tag='docker'"


### PR DESCRIPTION
Docker 1.7 has limited support for syslog logging. Can't configure facility and tag (In 1.9 you can do that).
1.7: https://docs.docker.com/v1.7/docker/reference/run/#logging-drivers-log-driver
1.9: https://docs.docker.com/engine/reference/logging/overview/
1.9: https://docs.docker.com/engine/reference/logging/log_tags/

**/var/log/messages** (after configuring logging to syslog):
> Feb  2 15:50:10 kenobi-uaa-of kernel: docker0: port 1(veth0e300e9) entering forwarding state
> Feb  2 15:50:10 kenobi-uaa-of docker/a3ca5c4f99d7[14522]: 
> Feb  2 15:50:10 kenobi-uaa-of docker/a3ca5c4f99d7[14522]: Hello from Docker.
> ...
> Feb  2 15:50:10 kenobi-uaa-of docker/a3ca5c4f99d7[14522]:  https://docs.docker.com/userguide/
> Feb  2 15:50:10 kenobi-uaa-of docker/a3ca5c4f99d7[14522]: 
> Feb  2 15:50:10 kenobi-uaa-of kernel: docker0: port 1(veth0e300e9) entering disabled state

