### PR TITLE
shutdown guest instead of suspend

### DIFF
--- a/bin/public/installKvmHost.py
+++ b/bin/public/installKvmHost.py
@@ -197,4 +197,4 @@ def _libvirt_init_config():
     #Initialize augeas
     augeas = Augeas(x)
 
-    augeas.set_enhanced("/files/etc/sysconfig/libvirt-guests/ON_SHUTDOWN shutdown")
+    augeas.set_enhanced("/files/etc/sysconfig/libvirt-guests/ON_SHUTDOWN","shutdown")

--- a/bin/public/installKvmHost.py
+++ b/bin/public/installKvmHost.py
@@ -193,6 +193,7 @@ def _abort_kvm_host_installation():
 
 def _libvirt_init_config():
 
+    x("yum install augeas -y")
     #Initialize augeas
     augeas = Augeas(x)
 

--- a/bin/public/installKvmHost.py
+++ b/bin/public/installKvmHost.py
@@ -47,6 +47,7 @@ import iptables
 import net
 import netUtils
 import version
+from augeas import Augeas
 
 # The version of this module, used to prevent
 # the same script version to be executed more then
@@ -191,4 +192,8 @@ def _abort_kvm_host_installation():
     raise Exception("Abort kvm host installation.")
 
 def _libvirt_init_config():
-    x("sed -i 's/ON_SHUTDOWN=suspend/ON_SHUTDOWN=shutdown/g' /etc/init.d/libvirt-guests")
+
+    #Initialize augeas
+    augeas = Augeas(x)
+
+    augeas.set_enhanced("/files/etc/sysconfig/libvirt-guests/ON_SHUTDOWN shutdown")

--- a/bin/public/installKvmHost.py
+++ b/bin/public/installKvmHost.py
@@ -117,6 +117,7 @@ def install_kvmhost(args):
 
     iptables.add_kvm_chain()
     iptables.save()
+    _libvirt_init_config()
 
     version_obj.mark_executed()
 
@@ -188,3 +189,6 @@ def _abort_kvm_host_installation():
 
     '''
     raise Exception("Abort kvm host installation.")
+
+def _libvirt_init_config():
+    x("sed -i 's/ON_SHUTDOWN=suspend/ON_SHUTDOWN=shutdown/g' /etc/init.d/libvirt-guests")


### PR DESCRIPTION
For faster reboot of vhost and for the guest to load eventual new kernel at the same time. 