### PR TITLE
Docker: support http proxy

### DIFF
--- a/bin/public/installDocker.py
+++ b/bin/public/installDocker.py
@@ -16,6 +16,7 @@ __status__ = "Production"
 
 from general import x
 import app
+import config
 import version
 
 
@@ -40,6 +41,17 @@ def install_docker(args):
     x('yum -y install docker-engine')
 
     x('cp %s/docker/docker /etc/sysconfig/docker' % app.SYCO_VAR_PATH)
+
+    # http://stackoverflow.com/questions/23111631/cannot-download-docker-images-behind-a-proxy
+    docker_conf = scOpen(filename='/etc/sysconfig/docker')
+    proxy_host = config.general.get_proxy_host()
+    proxy_port = config.general.get_proxy_port()
+    if proxy_host != "" and proxy_port != "":
+        docker_conf.replace('%HTTP_PROXY%', 'export HTTP_PROXY="http://%s:%s"' % (proxy_host, proxy_port))
+        docker_conf.replace('%HTTPS_PROXY%', 'export HTTPS_PROXY="https://%s:%s"' % (proxy_host, proxy_port))
+    else
+        docker_conf.replace('%HTTP_PROXY%', '')
+        docker_conf.replace('%HTTPS_PROXY%', '')
 
     x('chkconfig docker on')
     x('service docker start')

--- a/var/docker/docker
+++ b/var/docker/docker
@@ -8,6 +8,6 @@
 %HTTPS_PROXY%
 
 other_args_net="-H unix:///var/run/docker.sock -H tcp://0.0.0.0:2375"
-other_args_log="--log-driver=syslog --log-opt syslog-address=tcp://localhost:514"
+other_args_log="--log-driver=syslog --log-opt syslog-address=udp://localhost:514"
 
 other_args="${other_args_net} ${other_args_log}"

--- a/var/docker/docker
+++ b/var/docker/docker
@@ -4,6 +4,9 @@
 # These will be parsed by the sysv initscript and appended
 # to the arguments list passed to docker -d
 
+%HTTP_PROXY%
+%HTTPS_PROXY%
+
 other_args_net="-H unix:///var/run/docker.sock -H tcp://0.0.0.0:2375"
 other_args_log="--log-driver=syslog --log-opt syslog-address=tcp://localhost:514"
 


### PR DESCRIPTION
Read proxy config from `config.general.get_proxy_host()` and `config.general.get_proxy_port()` and configure docker runtime to use it if any